### PR TITLE
remove strong reference of IMKTextInput

### DIFF
--- a/macosfrontend/macosfrontend.swift
+++ b/macosfrontend/macosfrontend.swift
@@ -40,11 +40,8 @@ private func isJetBrains(_ app: String) -> Bool {
 
 nonisolated(unsafe) private var controller: IMKInputController? = nil
 
-nonisolated(unsafe) private var client: IMKTextInput? = nil
-
-public func setController(_ ctrl: Any, _ cli: Any?) {
+public func setController(_ ctrl: Any) {
   controller = ctrl as? IMKInputController
-  client = cli as? IMKTextInput
 }
 
 @MainActor
@@ -140,7 +137,7 @@ public func commitAndSetPreeditAsync(
   _ commit: String, _ preedit: String, _ caretPos: Int, _ dummyPreedit: Bool
 ) {
   Task { @MainActor in
-    guard let client = client else {
+    guard let client = controller?.client() else {
       return
     }
     commitAndSetPreeditSync(client, commit, preedit, caretPos, dummyPreedit)
@@ -149,7 +146,7 @@ public func commitAndSetPreeditAsync(
 
 public func commitAsync(_ commit: String) {
   Task { @MainActor in
-    guard let client = client else {
+    guard let client = controller?.client() else {
       return
     }
     commitString(client, commit)
@@ -157,7 +154,7 @@ public func commitAsync(_ commit: String) {
 }
 
 public func getSurroundingText(_ location: Int, _ length: Int) -> (String, UInt32, UInt32) {
-  guard let client = client, location != NSNotFound else {
+  guard let client = controller?.client(), location != NSNotFound else {
     return ("", 0, 0)
   }
   let totalLength = client.length()
@@ -187,7 +184,7 @@ public func getSurroundingText(_ location: Int, _ length: Int) -> (String, UInt3
 // It's called from C++ within dispatch_async(dispatch_get_main_queue())
 // so we can mark corresponding variables as nonisolated(unsafe).
 public func getCaretCoordinates(_ followCaret: Bool) -> [Double] {
-  guard let client = client else {
+  guard let client = controller?.client() else {
     return []
   }
   var rect = NSRect(x: 0, y: 0, width: 0, height: 0)
@@ -211,13 +208,15 @@ public func getCaretCoordinates(_ followCaret: Bool) -> [Double] {
 
 // Called from C++ within dispatch_async(dispatch_get_main_queue())
 public func getSelection() -> String {
-  guard let range = client?.selectedRange(),
-    range.location != NSNotFound
-  else {
+  guard let client = controller?.client() else {
+    return ""
+  }
+  let range = client.selectedRange()
+  if range.location == NSNotFound {
     return ""
   }
   var actualRange = NSRange(location: 0, length: 0)
-  return client?.string(from: range, actualRange: &actualRange) ?? ""
+  return client.string(from: range, actualRange: &actualRange) ?? ""
 }
 
 // Call it on
@@ -231,5 +230,5 @@ public func overrideKeyboardLayout() {
   let layout = String(get_current_group_layout())
   let appleLayout = layout == "PinyinKeyboard" ? "PinyinKeyboard" : layoutMap[layout] ?? "ABC"
   FCITX_DEBUG("Override keyboard layout to \(appleLayout)")
-  client?.overrideKeyboard(withKeyboardNamed: "com.apple.keylayout.\(appleLayout)")
+  controller?.client()?.overrideKeyboard(withKeyboardNamed: "com.apple.keylayout.\(appleLayout)")
 }

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -152,8 +152,8 @@ class FcitxInputController: IMKInputController {
     // to blur, drag the browser to somewhere else, click the address bar and type, the candidate
     // window is placed in wrong position (actually the most recent call is deactivateServer wtf).
     // Fortunately handle is called regardless of activateServer call. IMK being IMK.
-    // Before 7244f30 the client is stored in C++ side, thus calling ic->focusIn inside
-    // MacosFrontend::keyEvent lets the correct client be used by getCaretCoordinates, which serves
+    // Before 7244f30 the client was stored in C++ side, thus calling ic->focusIn inside
+    // MacosFrontend::keyEvent let the correct client be used by getCaretCoordinates, which served
     // the same purpose here.
     setController(self)
 

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -21,7 +21,6 @@ class FcitxInputController: IMKInputController {
   let appId: String
   let isPasswordOnlyApp: Bool
   let accentColor: String
-  let client: Any!
 
   var lastModifiers = NSEvent.ModifierFlags(rawValue: 0)
   var selection: NSRange? = nil
@@ -36,10 +35,9 @@ class FcitxInputController: IMKInputController {
     self.appId = (client as? IMKTextInput)?.bundleIdentifier() ?? ""
     self.isPasswordOnlyApp = isPasswordOnly(app: self.appId)
     self.accentColor = getAccentColor(appId)
-    self.client = client
     self.uuid = create_input_context(appId, accentColor)
     super.init(server: server, delegate: delegate, client: client)
-    setController(self, self.client)
+    setController(self)
     // On Chrome's home page execute document.addEventListener('keydown', console.log),
     // restart Fcitx5, click another app, then click blank area of Chrome's home page.
     // Now FcitxInputController is created but activateServer is not called, so we have
@@ -52,7 +50,7 @@ class FcitxInputController: IMKInputController {
   }
 
   override func commitComposition(_ sender: Any!) {
-    guard let client = client as? IMKTextInput else {
+    guard let client = client() else {
       return
     }
     let res = String(commit_composition(uuid))
@@ -98,7 +96,7 @@ class FcitxInputController: IMKInputController {
   }
 
   func processKey(_ unicode: UInt32, _ modsVal: UInt32, _ code: UInt16, _ isRelease: Bool) -> Bool {
-    guard let client = client as? IMKTextInput else {
+    guard let client = client() else {
       return false
     }
     // It can change within an IMKInputController (e.g. sudo in Terminal), so must reevaluate before each key sent to IM.
@@ -157,7 +155,7 @@ class FcitxInputController: IMKInputController {
     // Before 7244f30 the client is stored in C++ side, thus calling ic->focusIn inside
     // MacosFrontend::keyEvent lets the correct client be used by getCaretCoordinates, which serves
     // the same purpose here.
-    setController(self, self.client)
+    setController(self)
 
     let code = event.keyCode
     let mods = event.modifierFlags
@@ -193,7 +191,7 @@ class FcitxInputController: IMKInputController {
 
   // activateServer is called when app is in foreground but not necessarily a text field is selected.
   override func activateServer(_ client: Any!) {
-    setController(self, self.client)
+    setController(self)
     // Make sure status bar is updated on click password input, before first key event.
     let isPassword = getSecureInputInfo(isOnFocus: true)
     focus_in(uuid, isPassword)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined input controller integration for more consistent communication between the macOS frontend and input services.
  * Simplified controller setup and activation handling.
  * Preserved existing behavior for text commits, surrounding text, caret coordinates, selection, keyboard layouts, and input events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->