### PR TITLE
force NumLock for xkb

### DIFF
--- a/macosfrontend/macosfrontend.cpp
+++ b/macosfrontend/macosfrontend.cpp
@@ -37,6 +37,10 @@ void overrideKeyboardLayoutAsync() {
 MacosFrontend::MacosFrontend(Instance *instance)
     : instance_(instance),
       focusGroup_("macos", instance->inputContextManager()) {
+    // macOS's keypad is always number and never navigation. It doesn't support
+    // NumLock. Force NumLock for xkb so that keyboard-cn can produce numbers.
+    instance_->updateXkbStateMask(focusGroup_.display(), 0, 0,
+                                  static_cast<uint32_t>(KeyState::NumLock));
     // For update when switching internal input method of rime.
     eventHandlers_.emplace_back(instance_->watchEvent(
         EventType::InputContextUpdateUI, EventWatcherPhase::Default,


### PR DESCRIPTION
Fixes #401

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS keypad input handling by ensuring NumLock is enabled for numeric keyboard input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->