### PR TITLE
localize key representation

### DIFF
--- a/keycode/keycode-public.h
+++ b/keycode/keycode-public.h
@@ -16,3 +16,4 @@ std::string osx_key_to_fcitx_string(uint32_t unicode, uint32_t modifiers,
 std::string fcitx_string_to_osx_keysym(const char *) noexcept;
 uint32_t fcitx_string_to_osx_modifiers(const char *) noexcept;
 uint16_t fcitx_string_to_osx_keycode(const char *) noexcept;
+std::string fcitx_string_to_localized_string(const char *) noexcept;

--- a/keycode/keycode.cpp
+++ b/keycode/keycode.cpp
@@ -342,6 +342,11 @@ uint32_t fcitx_keystates_to_osx_modifiers(fcitx::KeyStates ks) {
     return ret;
 }
 
+std::string fcitx_string_to_localized_string(const char *s) noexcept {
+    fcitx::Key key{s};
+    return key.toString(fcitx::KeyStringFormat::Localized);
+}
+
 std::string fcitx_string_to_osx_keysym(const char *s) noexcept {
     fcitx::Key key{s};
     return fcitx_keysym_to_osx_keysym(key.sym());

--- a/src/config/KeyView.swift
+++ b/src/config/KeyView.swift
@@ -1,6 +1,7 @@
+import Keycode
 import SwiftUI
 
-func recordedKeyView(_ pair: (String, String?)) -> some View {
+private func recordedKeyView(_ pair: (String, String?)) -> some View {
   let (normalFont, smallerFont) = pair
   if let smallerFont = smallerFont {
     return Text(normalFont) + Text(smallerFont).font(.caption)
@@ -27,8 +28,7 @@ struct KeyView: OptionViewProtocol {
       recordedKeyView(
         value as? String == "" ? ("●REC", nil) : fcitxStringToMacShortcut(value as? String ?? "")
       )
-      .frame(
-        minWidth: 100)
+      .frame(minWidth: 100)
     }.sheet(isPresented: $showRecorder) {
       VStack {
         recordedKeyView(recordedShortcut)
@@ -55,7 +55,8 @@ struct KeyView: OptionViewProtocol {
       }.padding()
     }.help(
       value as? String == ""
-        ? NSLocalizedString("Click to record", comment: "") : value as? String ?? ""
+        ? NSLocalizedString("Click to record", comment: "")
+        : String(fcitx_string_to_localized_string(value as? String ?? ""))
     )
     .accessibilityIdentifier(data["Option"] as? String ?? "")
   }

--- a/src/config/keycode.swift
+++ b/src/config/keycode.swift
@@ -47,7 +47,7 @@ func fcitxStringToMacShortcut(_ s: String) -> (String, String?) {
   let modifiers = NSEvent.ModifierFlags(rawValue: UInt(fcitx_string_to_osx_modifiers(s)))
   let code = fcitx_string_to_osx_keycode(s)
   if key.isEmpty && code == 0 {
-    return (s, nil)
+    return (String(fcitx_string_to_localized_string(s)), nil)
   }
   return shortcutRepr(key, modifiers, code)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized display support for Fcitx key combinations.
  * Recorded Fcitx shortcuts now appear as readable, localized key names in help text and configuration views.

* **Bug Fixes**
  * Improved fallback behavior when a Fcitx key cannot be resolved, showing its localized representation instead of raw input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->