### PR TITLE
regression: Shift+Click produces 'a' on VSCode since 5cf1ae4

### DIFF
--- a/keycode/keycode.cpp
+++ b/keycode/keycode.cpp
@@ -265,6 +265,9 @@ fcitx::KeySym osx_unicode_to_fcitx_keysym(uint32_t unicode,
             return pair.sym;
         }
     }
+    if (unicode == 0) {
+        return FcitxKey_None;
+    }
     // If com.apple.keylayout.PinyinKeyboard is used, we need to map Chinese
     // punctuations back to ASCII so that engines can handle them properly, e.g.
     // Rime when typing pinyin followed by comma. The us layout gives the

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -124,7 +124,8 @@ class FcitxInputController: IMKInputController {
       } else if (modsVal == 0 || modsVal == capsLock) && lastEventIsShiftPress && selectionChanged {
         // Shift release following press when text selection is changed.
         // Send a no-op key event to fcitx so that Shift+Click doesn't trigger im toggle.
-        process_key(uuid, 0, 0, 0, false, isPassword, surroundingText, cursor, anchor)
+        // Code should not be 0 as it's macOS's kVK_ANSI_A.
+        process_key(uuid, 0, 0, 0xff, false, isPassword, surroundingText, cursor, anchor)
       }
       Task { @MainActor in
         ModifierState.shared.shift = isShiftPress

--- a/tests/testkey.cpp
+++ b/tests/testkey.cpp
@@ -2,11 +2,16 @@
 #include "fcitx-utils/log.h"
 #include "keycode.h"
 
+#define kVK_DUMMY 0xff
+
 void test_osx_to_fcitx() {
-    FCITX_ASSERT(osx_unicode_to_fcitx_keysym('0', 0, 0) == FcitxKey_0);
+    FCITX_ASSERT(osx_unicode_to_fcitx_keysym('0', 0, kVK_DUMMY) == FcitxKey_0);
     FCITX_ASSERT(osx_unicode_to_fcitx_keysym('0', 0, kVK_ANSI_Keypad0) ==
                  FcitxKey_KP_0);
-    FCITX_ASSERT(osx_unicode_to_fcitx_keysym('a', 0, 0) == FcitxKey_a);
+    FCITX_ASSERT(osx_unicode_to_fcitx_keysym('a', 0, kVK_DUMMY) == FcitxKey_a);
+    FCITX_ASSERT(osx_unicode_to_fcitx_keysym(0, 0, kVK_DUMMY) == FcitxKey_None);
+    FCITX_ASSERT(osx_unicode_to_fcitx_keysym(
+                     0, 0, kVK_ANSI_A /* 0, common error */) == FcitxKey_None);
 
     ::pinyinKeyboard = true;
     FCITX_ASSERT(osx_unicode_to_fcitx_keysym(65292 /* ， */, 0,
@@ -18,6 +23,9 @@ void test_osx_to_fcitx() {
                      12299 /* 》 */,
                      NSEventModifierFlagShift | NSEventModifierFlagControl,
                      kVK_ANSI_Period) == FcitxKey_period);
+    FCITX_ASSERT(osx_unicode_to_fcitx_keysym(0, 0, kVK_DUMMY) == FcitxKey_None);
+    FCITX_ASSERT(osx_unicode_to_fcitx_keysym(
+                     0, 0, kVK_ANSI_A /* 0, common error */) == FcitxKey_None);
     ::pinyinKeyboard = false;
 
     FCITX_ASSERT(osx_keycode_to_fcitx_keycode(kVK_ANSI_0) == 11 + 8);


### PR DESCRIPTION
Originally reported on Word, where trigger is Shift+Up, since it doesn't send Up to input method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty or zero-value keyboard input.
  * Corrected key state handling after selection changes, improving keyboard behavior on macOS.
* **Tests**
  * Added coverage for zero-value Unicode input and dummy keycode scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->