### PR TITLE
quick phrase paging

### DIFF
--- a/appium/test_quick_phrase.py
+++ b/appium/test_quick_phrase.py
@@ -2,6 +2,8 @@ from pathlib import Path
 
 from appium.webdriver.webdriver import WebDriver
 from util.button import get_label
+from util.enum import select_enum_option
+from util.integer import get_integer_value
 from util.message import (
     ASSUMPTION_OUTDATED,
     BUTTON_SHOULD_BE_DISABLED,
@@ -9,26 +11,59 @@ from util.message import (
     INTERNAL_TOOL_ERROR,
     UI_NOT_UPDATED,
 )
+from util.string import get_string_value
 from util.window import (
     close_sheet,
     find_element_by_id,
+    find_elements_by_id,
     open_input_method_config,
     scroll_to,
 )
 
-BUILTIN_NAME = "emoji"
+BUILTIN_NAME = "emoji-eac"
+PAGE_SIZE = 10
+GLOBAL_QUICKPHRASE_DIR = Path(
+    "/Library/Input Methods/Fcitx5.app/Contents/share/fcitx5/data/quickphrase.d"
+)
+CUSTOM_NAME = "test"
+
+
+def _open_quick_phrase(driver: WebDriver) -> None:
+    open_input_method_config(driver, "pinyin")
+    scroll_to(
+        find_element_by_id(driver, "detailScrollView"),
+        "QuickPhrase",
+    ).click()
 
 
 def test_builtin_quick_phrase(driver: WebDriver, app: str):
     quickphrase_dir = Path(app).parent / "data" / "data" / "quickphrase.d"
     local_file = quickphrase_dir / f"{BUILTIN_NAME}.mb"
     disabled_file = quickphrase_dir / f"{BUILTIN_NAME}.mb.disable"
+    builtin_file = GLOBAL_QUICKPHRASE_DIR / f"{BUILTIN_NAME}.mb"
+    item_count = sum(
+        len(line.split(maxsplit=1)) == 2
+        for line in builtin_file.read_text().splitlines()
+    )
+    expected_pages = max(1, (item_count + PAGE_SIZE - 1) // PAGE_SIZE)
 
-    open_input_method_config(driver, "pinyin")
-    scroll_to(
-        find_element_by_id(driver, "detailScrollView"),
-        "QuickPhrase",
-    ).click()
+    _open_quick_phrase(driver)
+    select_enum_option(find_element_by_id(driver, "QuickPhraseFile"), BUILTIN_NAME)
+
+    previous_page = find_element_by_id(driver, "chevron.left")
+    next_page = find_element_by_id(driver, "chevron.right")
+    page = find_element_by_id(driver, "Page")
+    total_pages = find_element_by_id(driver, "TotalPages")
+    assert get_integer_value(page) == 1, UI_NOT_UPDATED
+    assert get_string_value(total_pages) == f"/ {expected_pages}", UI_NOT_UPDATED
+    assert len(find_elements_by_id(driver, "Keyword")) == min(PAGE_SIZE, item_count), (
+        UI_NOT_UPDATED
+    )
+    assert previous_page.is_enabled() is False, UI_NOT_UPDATED
+    assert next_page.is_enabled() is (expected_pages > 1), UI_NOT_UPDATED
+    if expected_pages > 1:
+        next_page.click()
+        assert get_integer_value(page) == 2, UI_NOT_UPDATED
 
     toggle = find_element_by_id(driver, "ToggleOrRemove")
     assert get_label(toggle) == "Disable", UI_NOT_UPDATED
@@ -42,6 +77,7 @@ def test_builtin_quick_phrase(driver: WebDriver, app: str):
     toggle.click()
     toggle = find_element_by_id(driver, "ToggleOrRemove")
     assert get_label(toggle) == "Enable", UI_NOT_UPDATED
+    assert get_integer_value(find_element_by_id(driver, "Page")) == 1, UI_NOT_UPDATED
     assert not local_file.exists(), INTERNAL_TOOL_ERROR
     assert disabled_file.read_bytes() == b"", CHANGE_NOT_SAVED
 
@@ -51,4 +87,43 @@ def test_builtin_quick_phrase(driver: WebDriver, app: str):
     assert not disabled_file.exists(), CHANGE_NOT_SAVED
     assert not local_file.exists(), INTERNAL_TOOL_ERROR
 
+    close_sheet(driver)
+
+
+def test_create_quick_phrase_file(driver: WebDriver, app: str):
+    quickphrase_dir = Path(app).parent / "data" / "data" / "quickphrase.d"
+    custom_file = quickphrase_dir / f"{CUSTOM_NAME}.mb"
+
+    assert not custom_file.exists(), ASSUMPTION_OUTDATED
+    _open_quick_phrase(driver)
+
+    find_element_by_id(driver, "NewFile").click()
+    name = find_element_by_id(driver, "NewFileName")
+    name.click()
+    name.send_keys(CUSTOM_NAME)
+    find_element_by_id(driver, "CreateFile").click()
+
+    assert custom_file.read_bytes() == b"", CHANGE_NOT_SAVED
+    toggle = find_element_by_id(driver, "ToggleOrRemove")
+    assert get_label(toggle) == "Remove", UI_NOT_UPDATED
+
+    find_element_by_id(driver, "AddItem").click()
+    keyword = find_element_by_id(driver, "Keyword")
+    keyword.click()
+    keyword.send_keys("foo")
+    phrase = find_element_by_id(driver, "Phrase")
+    phrase.click()
+    phrase.send_keys("bar")
+    find_element_by_id(driver, "Save").click()
+
+    assert custom_file.read_text() == "foo bar\n", CHANGE_NOT_SAVED
+    assert get_string_value(find_element_by_id(driver, "Keyword")) == "foo", (
+        UI_NOT_UPDATED
+    )
+    assert get_string_value(find_element_by_id(driver, "Phrase")) == "bar", (
+        UI_NOT_UPDATED
+    )
+
+    find_element_by_id(driver, "ToggleOrRemove").click()
+    assert not custom_file.exists(), CHANGE_NOT_SAVED
     close_sheet(driver)

--- a/src/config/CustomPhrase.swift
+++ b/src/config/CustomPhrase.swift
@@ -117,30 +117,7 @@ struct CustomPhraseView: View {
             }
           }
         }
-        HStack {
-          Button {
-            currentPage = max(0, currentPage - 1)
-          } label: {
-            Image(systemName: "chevron.left")
-          }.disabled(currentPage == 0)
-          TextField(
-            "",
-            value: Binding(
-              get: { currentPage + 1 },
-              set: { currentPage = max(0, min(totalPages - 1, $0 - 1)) }
-            ), formatter: numberFormatter
-          )
-          .frame(width: 50)
-          .multilineTextAlignment(.center)
-          .accessibilityIdentifier("Page")
-          Text("/ \(totalPages)")
-            .accessibilityIdentifier("TotalPages")
-          Button {
-            currentPage = min(totalPages - 1, currentPage + 1)
-          } label: {
-            Image(systemName: "chevron.right")
-          }.disabled(currentPage >= totalPages - 1)
-        }
+        PaginationView(currentPage: $currentPage, totalPages: totalPages)
       }
 
       VStack {

--- a/src/config/QuickPhrase.swift
+++ b/src/config/QuickPhrase.swift
@@ -91,6 +91,8 @@ struct QuickPhraseView: View {
 
   @State private var showNewFile = false
   @State private var newFileName = ""
+  private let pageSize = 10
+  @State private var currentPage = 0
   @ObservedObject private var quickphraseVM = QuickPhraseVM()
   @State private var showReloaded = false
   @State private var showCreateFailed = false
@@ -99,6 +101,7 @@ struct QuickPhraseView: View {
   @State private var showSavedFailure = false
 
   func refreshFiles() -> some View {
+    currentPage = 0
     quickphraseVM.refreshFiles()
     return self
   }
@@ -111,6 +114,35 @@ struct QuickPhraseView: View {
   private var isCurrentFileEditable: Bool {
     let file = quickphraseVM.current
     return !file.isEmpty && !quickphraseVM.isBuiltin(file) && !quickphraseVM.isDisabled(file)
+  }
+
+  private var totalPages: Int {
+    let itemCount = quickphraseVM.quickPhrases[quickphraseVM.current]?.count ?? 0
+    return max(1, (itemCount + pageSize - 1) / pageSize)
+  }
+
+  private var currentPageItems: Range<Int> {
+    let itemCount = quickphraseVM.quickPhrases[quickphraseVM.current]?.count ?? 0
+    let start = currentPage * pageSize
+    let end = min(start + pageSize, itemCount)
+    guard start < end else { return 0..<0 }
+    return start..<end
+  }
+
+  private var currentPageSlice: Binding<[QuickPhrase]> {
+    let file = quickphraseVM.current
+    let range = currentPageItems
+    return Binding(
+      get: {
+        guard let quickPhrases = quickphraseVM.quickPhrases[file] else { return [] }
+        return Array(quickPhrases[range])
+      },
+      set: { newValue in
+        for (i, item) in zip(range, newValue) {
+          quickphraseVM.quickPhrases[file]?[i] = item
+        }
+      }
+    )
   }
 
   private func setBuiltinQuickPhraseEnabled(_ enabled: Bool) -> Bool {
@@ -132,6 +164,10 @@ struct QuickPhraseView: View {
             Text(file)
           }
         }
+        .accessibilityIdentifier("QuickPhraseFile")
+        .onChange(of: quickphraseVM.current) { _ in
+          currentPage = 0
+        }
         List(selection: $quickphraseVM.selectedRows) {
           HStack {
             Text("Keyword").frame(
@@ -141,30 +177,34 @@ struct QuickPhraseView: View {
           }
           .font(.headline)
 
-          ForEach(
-            Binding(
-              get: { quickphraseVM.quickPhrases[quickphraseVM.current] ?? [] },
-              set: { quickphraseVM.quickPhrases[quickphraseVM.current] = $0 }
-            )
-          ) { $quickPhrase in
+          ForEach(currentPageSlice) { $quickPhrase in
             // Disallow editing built-in files, but still use TextField for disabled status so that there is visual difference for enabled/disabled.
             HStack {
               if quickphraseVM.isBuiltin(quickphraseVM.current)
                 && !quickphraseVM.isDisabled(quickphraseVM.current)
               {
                 Text(quickPhrase.keyword).frame(
-                  minWidth: minKeywordColumnWidth, maxWidth: .infinity, alignment: .leading)
+                  minWidth: minKeywordColumnWidth, maxWidth: .infinity, alignment: .leading
+                )
+                .accessibilityIdentifier("Keyword")
                 Text(quickPhrase.phrase).frame(
-                  minWidth: minPhraseColumnWidth, maxWidth: .infinity, alignment: .leading)
+                  minWidth: minPhraseColumnWidth, maxWidth: .infinity, alignment: .leading
+                )
+                .accessibilityIdentifier("Phrase")
               } else {
                 TextField("Keyword", text: $quickPhrase.keyword).frame(
-                  minWidth: minKeywordColumnWidth, maxWidth: .infinity, alignment: .leading)
+                  minWidth: minKeywordColumnWidth, maxWidth: .infinity, alignment: .leading
+                )
+                .accessibilityIdentifier("Keyword")
                 TextField("Phrase", text: $quickPhrase.phrase).frame(
-                  minWidth: minPhraseColumnWidth, maxWidth: .infinity, alignment: .leading)
+                  minWidth: minPhraseColumnWidth, maxWidth: .infinity, alignment: .leading
+                )
+                .accessibilityIdentifier("Phrase")
               }
             }
           }
         }.disabled(quickphraseVM.isDisabled(quickphraseVM.current))
+        PaginationView(currentPage: $currentPage, totalPages: totalPages)
       }
       VStack {
         Button {
@@ -178,11 +218,12 @@ struct QuickPhraseView: View {
           showNewFile = true
         } label: {
           Text("New file")
-        }
+        }.accessibilityIdentifier("NewFile")
 
         Button {
           let newItem = QuickPhrase(keyword: "", phrase: "")
           quickphraseVM.quickPhrases[quickphraseVM.current]?.append(newItem)
+          currentPage = totalPages - 1
           quickphraseVM.selectedRows = [newItem.id]
         } label: {
           Text("Add item")
@@ -194,6 +235,9 @@ struct QuickPhraseView: View {
             quickphraseVM.selectedRows.contains($0.id)
           }
           quickphraseVM.selectedRows.removeAll()
+          if currentPage >= totalPages {
+            currentPage = totalPages - 1
+          }
         } label: {
           Text("Remove items")
         }.disabled(quickphraseVM.selectedRows.isEmpty || !isCurrentFileEditable)
@@ -279,6 +323,7 @@ struct QuickPhraseView: View {
           HStack {
             Text("Name")
             TextField("", text: $newFileName)
+              .accessibilityIdentifier("NewFileName")
           }
           HStack {
             Button {
@@ -301,12 +346,13 @@ struct QuickPhraseView: View {
               Text("Create")
             }.buttonStyle(.borderedProminent)
               .disabled(newFileName.isEmpty || quickphraseVM.files.contains(newFileName))
+              .accessibilityIdentifier("CreateFile")
           }
         }.padding()
           .frame(minWidth: 200)
       }
     }.padding()
-      .frame(minWidth: 500, minHeight: 300)
+      .frame(minWidth: 600, minHeight: 400)
       .toast(isPresenting: $showReloaded) {
         AlertToast(
           displayMode: .hud, type: .complete(Color.green),

--- a/src/config/ui.swift
+++ b/src/config/ui.swift
@@ -27,6 +27,42 @@ extension View {
   }
 }
 
+struct PaginationView: View {
+  @Binding var currentPage: Int
+  let totalPages: Int
+
+  private var lastPage: Int {
+    max(0, totalPages - 1)
+  }
+
+  var body: some View {
+    HStack {
+      Button {
+        currentPage = max(0, currentPage - 1)
+      } label: {
+        Image(systemName: "chevron.left")
+      }.disabled(currentPage == 0)
+      TextField(
+        "",
+        value: Binding(
+          get: { currentPage + 1 },
+          set: { currentPage = max(0, min(lastPage, $0 - 1)) }
+        ), formatter: numberFormatter
+      )
+      .frame(width: 50)
+      .multilineTextAlignment(.center)
+      .accessibilityIdentifier("Page")
+      Text("/ \(totalPages)")
+        .accessibilityIdentifier("TotalPages")
+      Button {
+        currentPage = min(lastPage, currentPage + 1)
+      } label: {
+        Image(systemName: "chevron.right")
+      }.disabled(currentPage >= lastPage)
+    }
+  }
+}
+
 func urlButton(_ text: String, _ link: String) -> some View {
   Link(text, destination: URL(string: link)!)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination to quick phrase and custom phrase lists.
  * Added page navigation controls with direct page-number entry.
  * Quick phrase lists now display 10 entries per page.
  * Added support for creating, saving, and removing custom quick phrase files.

* **Bug Fixes**
  * Pagination now resets or adjusts automatically when files or entries change.
  * Improved accessibility labels for quick phrase and pagination controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->