### PR TITLE
switch to en on Software Update password field

### DIFF
--- a/macosfrontend/macosfrontend.swift
+++ b/macosfrontend/macosfrontend.swift
@@ -13,7 +13,7 @@ private let passwordOnlyApps: Set<String> = [
   // Below are apps that only have password fields but don't call EnableSecureEventInput.
   "com.apple.wifi.WiFiAgent",  // join wifi from wifi menu
   "com.apple.wifi-settings-extension",  // join wifi from System Settings
-  "com.apple.LocalAuthenticationRemoteService", // Software Update
+  "com.apple.LocalAuthenticationRemoteService",  // Software Update
 ]
 
 // Given issues when no preedit is so widespread regardless of UI framework,

--- a/macosfrontend/macosfrontend.swift
+++ b/macosfrontend/macosfrontend.swift
@@ -13,6 +13,7 @@ private let passwordOnlyApps: Set<String> = [
   // Below are apps that only have password fields but don't call EnableSecureEventInput.
   "com.apple.wifi.WiFiAgent",  // join wifi from wifi menu
   "com.apple.wifi-settings-extension",  // join wifi from System Settings
+  "com.apple.LocalAuthenticationRemoteService", // Software Update
 ]
 
 // Given issues when no preedit is so widespread regardless of UI framework,

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -86,6 +86,9 @@ class FcitxInputController: IMKInputController {
       let runningApp = pid == nil ? nil : NSRunningApplication(processIdentifier: pid!)
       obeySecureInput = runningApp?.bundleIdentifier == appId
       if !obeySecureInput {
+        // Logged:
+        // In Software Update, System Settings (com.apple.systempreferences) enables secure input,
+        // but password is typed into com.apple.LocalAuthenticationRemoteService.
         FCITX_WARN(
           "Secure input is abused by (possibly) \(runningApp?.localizedName ?? "?"): \(runningApp?.bundleIdentifier ?? "?") pid=\(pid ?? -1)"
         )


### PR DESCRIPTION
Typed wrong password several times. Turns out that shuangpin is not switched to en.

Log before typing password:
```
Imacosfrontend.cpp:297] Focus in com.apple.systempreferences
Override keyboard layout to PinyinKeyboard
Imacosfrontend.cpp:252] Create IC for com.apple.Software-Update-Settings.extension
Override keyboard layout to PinyinKeyboard
Dinstance.cpp:2498] Instance::deactivateInputMethod event_type=4100
Dinstance.cpp:2516] Deactivate: [Last]:shuangpin [Deactivating]:shuangpin
Dinstance.cpp:2456] Instance::activateInputMethod
Dinstance.cpp:2461] Activate: [Last]: [Activating]:shuangpin
Imacosfrontend.cpp:297] Focus in com.apple.Software-Update-Settings.extension
Imacosfrontend.cpp:342] Focus out com.apple.Software-Update-Settings.extension
Dinstance.cpp:2498] Instance::deactivateInputMethod event_type=4100
Dinstance.cpp:2516] Deactivate: [Last]:shuangpin [Deactivating]:shuangpin
Imacosfrontend.cpp:252] Create IC for com.apple.LocalAuthenticationRemoteService
Override keyboard layout to PinyinKeyboard
Secure input is abused by (possibly) System Settings: com.apple.systempreferences pid=29336
Dinstance.cpp:2456] Instance::activateInputMethod
Dinstance.cpp:2461] Activate: [Last]: [Activating]:shuangpin
Imacosfrontend.cpp:297] Focus in com.apple.LocalAuthenticationRemoteService
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved password entry behavior during Software Update by preventing unnecessary dummy preedit text while secure input is active.
  - Password fields handled through the system’s authentication service now behave consistently during secure input, reducing unexpected text or input artifacts.

- **Documentation**
  - Added clarification describing secure input behavior while entering passwords in System Settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->