### PR TITLE
regression: SwiftUI fallbacks to 15 on 26 since 46f5857

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,15 @@ set(CMAKE_FIND_FRAMEWORK LAST)
 add_compile_options(-target "${CMAKE_Swift_COMPILER_TARGET}")
 add_link_options(-target "${CMAKE_Swift_COMPILER_TARGET}")
 
+# When swiftc is invoked directly instead of through the /usr/bin trampoline,
+# it does not inherit SDKROOT. Xcode 26.6 then forwards the SDK to Clang as
+# --sysroot, which does not preserve the SDK version in LC_BUILD_VERSION.
+# Pass -isysroot to the Clang link job so macOS recognizes this as an app built
+# with the current SDK and enables the corresponding system UI appearance.
+add_link_options(
+    "$<$<LINK_LANGUAGE:Swift>:SHELL:-Xclang-linker -isysroot -Xclang-linker ${CMAKE_OSX_SYSROOT}>"
+)
+
 set(CMAKE_Swift_LANGUAGE_VERSION 6)
 # Disallow InitializeSwift to execute link_directories which adds Xcode paths to rpath.
 set(SWIFT_LIBRARY_SEARCH_PATHS "")

--- a/scripts/check-validity.sh
+++ b/scripts/check-validity.sh
@@ -3,6 +3,18 @@ set -e
 has_homebrew_deps=0
 has_xcode_rpath=0
 has_extra_dylib=0
+has_invalid_build_version=0
+
+project_root=$(cd "$(dirname "$0")/.." && pwd)
+deployment_target=$(sed -nE \
+  's/^[[:space:]]*set\(CMAKE_OSX_DEPLOYMENT_TARGET[[:space:]]+([0-9]+(\.[0-9]+)*)\).*$/\1/p' \
+  "$project_root/CMakeLists.txt")
+sdk_version=$(xcrun --sdk macosx --show-sdk-version)
+
+if [[ -z $deployment_target ]]; then
+  echo "Failed to read CMAKE_OSX_DEPLOYMENT_TARGET from $project_root/CMakeLists.txt" >&2
+  exit 8
+fi
 
 cd /Library/Input\ Methods/Fcitx5.app/Contents
 libs=(MacOS/Fcitx5)
@@ -25,4 +37,28 @@ for lib in "${libs[@]}"; do
   fi
 done
 
-exit $((has_homebrew_deps + has_xcode_rpath + has_extra_dylib))
+build_version=$(vtool -show-build MacOS/Fcitx5)
+
+check_build_version() {
+  local field=$1
+  local expected=$2
+
+  if ! awk -v field="$field" -v expected="$expected" '
+    $1 == field {
+      found = 1
+      if ($2 != expected) {
+        invalid = 1
+      }
+    }
+    END { exit !found || invalid }
+  ' <<< "$build_version"; then
+    echo "MacOS/Fcitx5 has an unexpected $field; expected $expected:" >&2
+    echo "$build_version" >&2
+    has_invalid_build_version=8
+  fi
+}
+
+check_build_version minos "$deployment_target"
+check_build_version sdk "$sdk_version"
+
+exit $((has_homebrew_deps + has_xcode_rpath + has_extra_dylib + has_invalid_build_version))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - macOS builds now preserve the selected SDK version in application metadata, improving compatibility with the current SDK.
  - Build validation now checks that the binary’s minimum macOS version and SDK version match the configured values.

- **Build Improvements**
  - Deployment-target or SDK mismatches are now reported as validation failures, helping identify incompatible macOS builds earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->