### PR TITLE
fix image url reset

### DIFF
--- a/appium/test_image.py
+++ b/appium/test_image.py
@@ -10,7 +10,7 @@ from util.file import select_files
 from util.key import press
 from util.message import ASSUMPTION_OUTDATED, CHANGE_NOT_SAVED, UI_NOT_UPDATED
 from util.string import get_string_value
-from util.window import find_element_by_id, open_theme_config
+from util.window import find_element_by_id, open_theme_config, reset_option
 
 BACKGROUND = "Background"
 PNG = "customized.png"
@@ -49,3 +49,8 @@ def test_image(driver: WebDriver, app: str):
     press(driver, [Keys.ENTER])
     assert get_string_value(url) == URL, UI_NOT_UPDATED
     assert read_config_value() == URL, CHANGE_NOT_SAVED
+
+    reset_option(driver, "ImageUrl")
+    assert read_config_value() == "", CHANGE_NOT_SAVED
+    assert get_enum_value(mode) == "Local", UI_NOT_UPDATED
+    assert get_label(get_button()) == prompt_label, UI_NOT_UPDATED

--- a/src/config/ImageView.swift
+++ b/src/config/ImageView.swift
@@ -68,9 +68,25 @@ struct ImageView: OptionViewProtocol {
         .accessibilityIdentifier("ImageURL")
       }
     }.onChange(of: file) {
-      value = $0.isEmpty ? "" : fcitxPrefix + $0
+      let newValue = $0.isEmpty ? "" : fcitxPrefix + $0
+      if mode == 0, (value as? String) != newValue {
+        value = newValue
+      }
     }.onChange(of: url) {
-      value = $0
+      if mode == 1, (value as? String) != $0 {
+        value = $0
+      }
+    }.onChange(of: value as? String) {
+      let newValue = $0 ?? ""
+      if newValue.isEmpty || newValue.starts(with: fcitxPrefix) {
+        mode = 0
+        file = String(newValue.dropFirst(fcitxPrefix.count))
+        url = ""
+      } else {
+        mode = 1
+        file = ""
+        url = newValue
+      }
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image source switching so local files and URLs remain synchronized correctly.
  - External image setting changes now update the selected mode and displayed source consistently.
  - Resetting the image setting now clears the saved value, restores Local mode, and returns the button to its original label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->